### PR TITLE
checking for ldap group ending _swift_grp before checking for _grp

### DIFF
--- a/sw2srv/views.py
+++ b/sw2srv/views.py
@@ -207,8 +207,13 @@ def verify(acct_name, username):
     binddn = request.authorization.username
     bindpw = request.authorization.password
 
+    # first see if there is a specific swift group that controls access
     is_ok, message, status_code = validate(
-        username, acct_name, binddn, bindpw, '_grp')
+        username, acct_name, binddn, bindpw, '_swift_grp')
+    # but if _swift_grp is not found use the default group ending _grp
+    if message.startswith('No directory group for account'):
+        is_ok, message, status_code = validate(
+            username, acct_name, binddn, bindpw, '_grp')
 
     if is_ok:
         server.logger.debug("returning credential")


### PR DESCRIPTION
@atombaby this is 100% untested. 

It should address the issue that v1 auth gives everyone in the _grp group full access. Since _grp also governs access for other file servers there may be too many users with write access. New behavior is that it checks for a _swift_grp group first and only goes to _grp if _swift_grp does not exist. 